### PR TITLE
Guide:Managing-image-files-in-DOSBox‐X.asciidoc - VHD size fix

### DIFF
--- a/Guide:Managing-image-files-in-DOSBox‐X.asciidoc
+++ b/Guide:Managing-image-files-in-DOSBox‐X.asciidoc
@@ -1076,14 +1076,14 @@ For example to create a 2GiB dynamic VHD image using the integrated `IMGMAKE` ut
 
 [source, console]
 ....
-imgmake hdd.vhd -t vhd -size 2097152
+imgmake hdd.vhd -t vhd -size 2048
 ....
 
 Or to create a 2GiB fixed-size VHD image using the integrated 'IMGMAKE' utility:
 
 [source, console]
 ....
-imgmake hdd.vhd -t hd -size 2097152
+imgmake hdd.vhd -t hd -size 2048
 ....
 
 The advantage of using `IMGMAKE` is that the created image file will be partitioned and formatted and as such is ready to be mounted.


### PR DESCRIPTION
Fixes https://github.com/joncampbell123/dosbox-x/issues/4935

2GB -size 2097152 is wrong.
Changed to 2GB -size 2048.

If the intent is to show example with 2TB, then correct will be 2TB -size 2088960
Slightly less than 2TB, but that's the [maximum supported](https://github.com/joncampbell123/dosbox-x/pull/4273#issuecomment-1563803886) by the [VHD format](https://learn.microsoft.com/en-us/previous-versions/windows/desktop/msvs/ivmvirtualserver-createfixedvirtualharddisk).